### PR TITLE
Receive multicast NOTIFY from lights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 
 # Created by https://www.gitignore.io/api/bower,django,phpstorm,webstorm,android,composer,maven,node,symfony,osx,svn,vagrant,windows
 
+# joe
+*~
+
 ### Maven ###
 target/
 pom.xml.tag

--- a/src/Yeelight.js
+++ b/src/Yeelight.js
@@ -44,7 +44,7 @@ export default class Yeelight extends EventEmitter {
 
     this.socket = new net.Socket();
 
-    this.socket.on('end', this.formatResponse.bind(this));
+    this.socket.on('data', this.formatResponse.bind(this));
 
     this.socket.connect(this.port, this.hostname, () => {
       this.log(`connected to ${this.name} ${this.hostname}:${this.port}`);

--- a/src/Yeelight.js
+++ b/src/Yeelight.js
@@ -168,7 +168,7 @@ export default class Yeelight extends EventEmitter {
    * smart LED, then a empty string value ("") will be returned.
    *
    * @example
-   * getValues(['power', 'bright']);
+   * getValues('power', 'bright');
    *
    * @returns {Promise} will be invoked after successfull or failed send
    */

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,13 @@ class YeelightSearch extends EventEmitter {
   getYeelightById(id) {
     return this.yeelights.find(item => item.getId() === id);
   }
+
+  /**
+   * refresh lights sending a new m-search
+   */
+  refresh() {
+    this.client.search('wifi_bulb');
+  }
 }
 
 module.exports = YeelightSearch;


### PR DESCRIPTION
With this changes we can receive multicast traffic that carries NOTIFY messages from lights so we can trigger a 'found' event when a light is powered on after we sent M-SEARCH or when the lights refresh status.

Also a simple refresh function is added.