### PR TITLE
Catch JSON.parse error on formatResponse() to prevent Yeelight from c…

### DIFF
--- a/src/Yeelight.js
+++ b/src/Yeelight.js
@@ -104,6 +104,7 @@ export default class Yeelight extends EventEmitter {
    * @param {string} resp response comming from the socket as a json string
    */
   formatResponse(resp) {
+    try {
     const json = JSON.parse(resp);
     const id = json.id;
     const result = json.result;
@@ -122,6 +123,10 @@ export default class Yeelight extends EventEmitter {
       this.emit('error', id, error);
     } else {
       this.emit('response', id, result);
+    }
+    }
+    catch(e) {
+      this.emit('error', e)
     }
   }
 


### PR DESCRIPTION
Hi,
I'm having an issue with `formatResponse()` crashing.
It 'll be good to catch `JSON.parse()` error.

Error :
```shell
undefined:2
{"id":3, "result":["ok"]}
^

SyntaxError: Unexpected token { in JSON at position 49
    at JSON.parse (<anonymous>)
    at Yeelight.formatResponse (C:\Users\Wifsimster\[...]\n
ode_modules\yeelight-wifi\build\Yeelight.js:153:23)
    at emitOne (events.js:115:13)
    at Socket.emit (events.js:210:7)
    at addChunk (_stream_readable.js:250:12)
    at readableAddChunk (_stream_readable.js:237:11)
    at Socket.Readable.push (_stream_readable.js:195:10)
    at TCP.onread (net.js:586:20)
```